### PR TITLE
Add root and data/ as pr template paths

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -464,12 +464,14 @@ func readDefaultPullRequestTemplate(repo *git.Repo) string {
 		"PULL_REQUEST_TEMPLATE.md",
 		"pull_request_template.md",
 	} {
-		tpl := filepath.Join(repo.Dir(), ".github", f)
-		data, err := os.ReadFile(tpl)
-		if err != nil {
-			continue
+		for _, dir := range []string{"", ".github", "data"} {
+			tpl := filepath.Join(repo.Dir(), dir, f)
+			data, err := os.ReadFile(tpl)
+			if err != nil {
+				continue
+			}
+			return string(data)
 		}
-		return string(data)
 	}
 	return ""
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
